### PR TITLE
Add timetable slots feature

### DIFF
--- a/lib/features/timetable/view/widgets/schedule_timeline.dart
+++ b/lib/features/timetable/view/widgets/schedule_timeline.dart
@@ -100,6 +100,7 @@ class ScheduleTimeline extends StatelessWidget {
               _buildInfoText(
                   '${classInfo.courseCode} - ${classInfo.courseType}', context),
               _buildInfoText(classInfo.venue, context),
+              _buildInfoText(classInfo.slot, context),
             ],
           ),
         ),


### PR DESCRIPTION
I have added a slot for the timetable schedule page...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display of class slot information in the schedule timeline, providing more details for each class entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->